### PR TITLE
Simulate a failing CSR with a client failure, not an IDNA failure.

### DIFF
--- a/src/txacme/test/test_service.py
+++ b/src/txacme/test/test_service.py
@@ -288,7 +288,7 @@ class AcmeIssuingServiceTests(TestCase):
         """
         now = datetime(2000, 1, 1, 0, 0, 0)
         certs = {
-            u'a' * 100: _generate_cert(
+            u'example.com': _generate_cert(
                 u'example.com',
                 not_valid_before=now - timedelta(seconds=1),
                 not_valid_after=now + timedelta(days=31)),
@@ -302,16 +302,23 @@ class AcmeIssuingServiceTests(TestCase):
                 succeeded(Is(None)))
             self.assertThat(fixture.responder.challenges, HasLength(0))
 
+            fixture.controller.pause()
             fixture.clock.advance(36 * 60 * 60)
+            # Resume the client.request_issuance deferred with an exception.
+            fixture.controller.resume(Failure(Exception()))
             self.assertThat(flush_logged_errors(), HasLength(1))
             self.assertThat(panics, Equals([]))
             self.assertThat(fixture.responder.challenges, HasLength(0))
 
+            fixture.controller.pause()
             fixture.clock.advance(15 * 24 * 60 * 60)
+            # Resume the client.request_issuance deferred with an exception.
+            fixture.controller.resume(Failure(Exception()))
             self.assertThat(
                 panics,
                 MatchesListwise([
-                    MatchesListwise([IsInstance(Failure), Equals(u'a' * 100)]),
+                    MatchesListwise([IsInstance(Failure),
+                                     Equals(u'example.com')]),
                     ]))
             self.assertThat(fixture.responder.challenges, HasLength(0))
 

--- a/src/txacme/testing.py
+++ b/src/txacme/testing.py
@@ -45,14 +45,17 @@ class FakeClientController(object):
         """
         self.paused = True
 
-    def resume(self):
+    def resume(self, value=None):
         """
         Resume issuing, allowing any pending issuances to proceed.
+
+        :param value: An (optional) value with which pending deferreds
+            will be called back.
         """
         _waiting = self._waiting
         self._waiting = []
         for d in _waiting:
-            d.callback(None)
+            d.callback(value)
 
     def count(self):
         """


### PR DESCRIPTION
cryptography >= 2.1 no longer IDNA encodes x509.DNSNames, so u'a' *
100 won't raise the expected "idna.core.IDNAError: Label too long"
error.

Causing FakeClient.request_issuance to errback simulates a remote
service or transport failure and results in AcmeIssuingService.issue
failing equivalently.  This is accomplished by allowing
FakeClientController.resume callers to pass values to pending
Deferreds and pausing the controller before advancing the clock, then
resuming it with a Failure.

Fixes #124.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/twisted/txacme/126)
<!-- Reviewable:end -->
