### PR TITLE
Migrate from acme.jose, which wasn't public API, to josepy, which is

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -307,6 +307,8 @@ intersphinx_mapping = {
                (None, 'python-objects.inv')),
     'acme': ('https://acme-python.readthedocs.io/en/latest/',
              (None, 'acme-objects.inv')),
+    'jose': ('https://josepy.readthedocs.io/en/latest/',
+             (None, 'jose-objects.inv')),
     'twisted': ('https://twisted.readthedocs.io/en/latest/',
                 (None, 'twisted-objects.inv')),
     'cryptography': ('https://cryptography.io/en/latest/',

--- a/src/integration/test_client.py
+++ b/src/integration/test_client.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 from functools import partial
 from os import getenv
 
-from acme.jose import JWKRSA
+from josepy.jwk import JWKRSA
 from acme.messages import NewRegistration, STATUS_PENDING
 from cryptography.hazmat.primitives import serialization
 from eliot import start_action

--- a/src/txacme/challenges/_libcloud.py
+++ b/src/txacme/challenges/_libcloud.py
@@ -3,7 +3,7 @@ import time
 from threading import Thread
 
 import attr
-from acme import jose
+from josepy.b64 import b64encode
 from libcloud.dns.providers import get_driver
 from twisted._threads import pool
 from twisted.internet.defer import Deferred
@@ -95,7 +95,7 @@ def _validation(response):
     Get the validation value for a challenge response.
     """
     h = hashlib.sha256(response.key_authorization.encode("utf-8"))
-    return jose.b64encode(h.digest()).decode()
+    return b64encode(h.digest()).decode()
 
 
 @attr.s(hash=False)

--- a/src/txacme/endpoint.py
+++ b/src/txacme/endpoint.py
@@ -6,7 +6,8 @@ from datetime import timedelta
 from functools import partial
 
 import attr
-from acme.jose import JWKRSA, RS256
+from josepy.jwk import JWKRSA
+from josepy.jwa import RS256
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from twisted.internet.defer import maybeDeferred

--- a/src/txacme/messages.py
+++ b/src/txacme/messages.py
@@ -7,7 +7,7 @@ provided by the `acme` library.
 ..  seealso:: `acme.messages`
 """
 from acme.fields import Resource
-from acme.jose import Field, JSONObjectWithFields
+from josepy import Field, JSONObjectWithFields
 
 from txacme.util import decode_csr, encode_csr
 

--- a/src/txacme/test/test_challenges.py
+++ b/src/txacme/test/test_challenges.py
@@ -4,7 +4,7 @@ Tests for `txacme.challenges`.
 from operator import methodcaller
 
 from acme import challenges
-from acme.jose import b64encode
+from josepy.b64 import b64encode
 from hypothesis import strategies as s
 from hypothesis import assume, example, given
 from testtools import skipIf, TestCase

--- a/src/txacme/test/test_endpoint.py
+++ b/src/txacme/test/test_endpoint.py
@@ -3,7 +3,7 @@ Tests for `txacme.endpoint`.
 """
 from datetime import datetime
 
-from acme.jose import JWKRSA
+from josepy.jwk import JWKRSA
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from fixtures import TempDir

--- a/src/txacme/test/test_util.py
+++ b/src/txacme/test/test_util.py
@@ -2,8 +2,8 @@ from codecs import decode
 
 import attr
 from acme import challenges
-from acme.jose import b64encode
-from acme.jose.errors import DeserializationError
+from josepy.b64 import b64encode
+from josepy.errors import DeserializationError
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -119,7 +119,7 @@ class CSRTests(TestCase):
     def test_decode_garbage(self):
         """
         If decoding fails, `~txacme.util.decode_csr` raises
-        `~acme.jose.errors.DeserializationError`.
+        `~josepy.errors.DeserializationError`.
         """
         with ExpectedException(DeserializationError):
             decode_csr(u'blah blah not a valid CSR')

--- a/src/txacme/util.py
+++ b/src/txacme/util.py
@@ -5,8 +5,9 @@ import uuid
 from datetime import datetime, timedelta
 from functools import wraps
 
-from acme import jose
-from acme.jose.errors import DeserializationError
+from josepy.errors import DeserializationError
+from josepy.json_util import encode_b64jose, decode_b64jose
+
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
@@ -106,7 +107,7 @@ def encode_csr(csr):
 
     :rtype: str
     """
-    return jose.encode_b64jose(csr.public_bytes(serialization.Encoding.DER))
+    return encode_b64jose(csr.public_bytes(serialization.Encoding.DER))
 
 
 def decode_csr(b64der):
@@ -120,7 +121,7 @@ def decode_csr(b64der):
     """
     try:
         return x509.load_der_x509_csr(
-            jose.decode_b64jose(b64der), default_backend())
+            decode_b64jose(b64der), default_backend())
     except ValueError as error:
         raise DeserializationError(error)
 


### PR DESCRIPTION
The current version of txacme cannot be `pip install`ed against the most recent release of `acme`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/twisted/txacme/130)
<!-- Reviewable:end -->
